### PR TITLE
fix compile issue

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAudioDSP/ActiveAudioDSP.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAudioDSP/ActiveAudioDSP.cpp
@@ -133,7 +133,7 @@ void* CActiveAudioDSP::GetControllerHandle(void * ControllerCallback)
 
 bool CActiveAudioDSP::ReleaseControllerHandle(void **Handle)
 {
-  return nullptr;
+  return false;
 }
 
 IActiveAEProcessingBuffer* CActiveAudioDSP::GetProcessingBuffer(const CActiveAEStream *AudioStream, AEAudioFormat &OutputFormat)


### PR DESCRIPTION


<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
error: converting to ‘bool’ from ‘std::nullptr_t’ requires direct-initialization

changed nullptr to false and it compiles now

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
didnt compile - does now
## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
hasn't - but at least it compiles
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
